### PR TITLE
Migrate to Github Actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,22 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.6, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Test with nose
+      run: |
+        pip install nose
+        nosetests

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,28 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-script: nosetests

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ libgravatar
 ===========
 
 
-.. image:: https://travis-ci.org/pabluk/libgravatar.png?branch=master
-        :target: https://travis-ci.org/pabluk/libgravatar
+.. image:: https://github.com/pabluk/libgravatar/actions/workflows/python-package.yml/badge.svg
+        :target: https://github.com/pabluk/libgravatar/actions/workflows/python-package.yml
 
 A library that provides a Python 3 interface for the Gravatar API.
 API details: https://en.gravatar.com/site/implement/


### PR DESCRIPTION
Migrate from Travis CI to Github Actions.

This PR:
* Removes Travis CI config
* Add an action for tests
 * Add an action for publish releases on Pypi.