### PR TITLE
Enable doctests with nose

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Test with nose
       run: |
         pip install nose
-        nosetests
+        nosetests --with-doctest --verbose


### PR DESCRIPTION
Set --with-doctest and --verbose options for nosetests in order to check doctest strings during testing.