### PR TITLE
Add support for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.8, 3.9]
+        python-version: ["2.7", "3.6", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Test with nose
+    - name: Test with pytest
       run: |
-        pip install nose
-        nosetests --with-doctest --verbose
+        pip install pytest
+        pytest --verbose --doctest-modules --color=yes

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["2.7", "3.6", "3.8", "3.9"]
+        python-version: ["2.7", "3.6", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -80,13 +80,13 @@ To contribute to this project or to test this library locally you'll need to ins
 
     python3 -m venv venv # for example on a virtual environment
     source venv/bin/activate
-    pip install nose black
+    pip install pytest black
 
 and you can validate your changes running:
 
 .. code-block:: shell
 
-    nosetests --with-doctest --verbose
+    pytest --doctest-modules --verbose
     black . --check --diff
 
 


### PR DESCRIPTION
As Python 3.10 and 3.11 are actively maintained this PR add support for those versions.

Nose was replaced because it was in maintenance mode and it doesn't support Python 3.10 or higher.