### PR TITLE
Resolve #15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,3 +98,4 @@ Author and contributors
 * Rarm NAGALINGAM (`@snowjet <https://github.com/snowjet/>`_)
 * Manan (`@mentix02 <https://github.com/mentix02/>`_)
 * Gareth Simpson (`@xurble <https://github.com/xurble/>`_)
+* Sean Kelly (`@nutjob4life <https://github.com/nutjob4life/>`_)

--- a/libgravatar/__init__.py
+++ b/libgravatar/__init__.py
@@ -249,7 +249,12 @@ def md5_hash(string):
     '0bc83cb571cd1c50ba6f3e8a78ef1346'
 
     """
-    return md5(string.encode("utf-8")).hexdigest()
+    try:
+        # On security-restricted systems, indicate we are fingerprinting only:
+        return md5(string.encode("utf-8"), usedforsecurity=False).hexdigest()
+    except TypeError:
+        # On systems without usedforsecurity:
+        return md5(string.encode("utf-8")).hexdigest()
 
 
 def default_url_is_valid(url):


### PR DESCRIPTION
Merge this to resolve #15. It passes the `usedforsecurity` flag with a `False` value to the MD5 hasher, which is disabled by default on security-restricted systems.

On older Pythons when the flag is unavailable, it reverts to calling the hasher without the flag.