### PR TITLE
Migrate to Read the Docs v2 build format

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==6.2.1
+sphinx-rtd-theme==1.2.2
+readthedocs-sphinx-search==0.3.1


### PR DESCRIPTION
Following the deprecation notice https://blog.readthedocs.com/migrate-configuration-v2/